### PR TITLE
CV Consumer Chain Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,18 @@
 
 A simple utility for watching pre-vote status on Tendermint chains. It will print out the current pre-vote status for each validator in the validator set. Useful for watching pre-votes during an upgrade or other network event causing a slowdown.
 
-## Usage
+## Basic Chain Usage
 
 ```
 pvtop tcp://localhost:26657
+```
+
+## Consumer Chain Usage
+
+This is only for consumer chains of the Cosmos Hub
+
+```
+pvtop tcp://consumer:26657 tcp://provider:26657
 ```
 
 ## Example


### PR DESCRIPTION
Normally a basic chain RPC provides both validator and consensus information.

However, Consumer chains of the Cosmos Hub do not contain validator details.

Allow a second argument to specify the RPC Host:Port for the Provider Chain (Cosmos Hub) to fetch validator details.