### PR TITLE
feat: allow scrolling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+pvtop


### PR DESCRIPTION
Fixes #10.

Now on pressing "up" or "down" buttons, it'll scroll to the top or the bottom. (Scrolling by 1 up or down is quite unintuitive, as it starts with selecting the 1st row, so if your screen fits 30 validators, you have to press down 29 times so it'll actually scroll on 30th, same with scrolling up).

I've also updated a splitVotes function to return the count of rows, as otherwise it may happen that columns do not have equal rows count, so when scrolling, one (fitting the screen) would be scrolled, and the other (not fitting the screen) would not, so we need to prefill the strings array with empty values to make it work properly