### PR TITLE
Reduce rows for shorter windows.  Decimals for prevote/commit.

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 		if propIdx >= 0 {
 			proposer = v.GetInfo(propIdx)
 		}
-		SummaryChan <- fmt.Sprintf("height/round/step: %s - v: %.0f%% c: %.0f%% (%v)\n\nProposer:\n(rank/%%/moniker) %s", hrs, votePct*100, commitPct*100, dur, proposer)
+		SummaryChan <- fmt.Sprintf("height/round/step: %s - v: %.2f%% c: %.2f%% (%v)\n\nProposer:\n(rank/%%/moniker) %s", hrs, votePct*100, commitPct*100, dur, proposer)
 		voteChan <- votes
 		votePctChan <- votePct
 		commitPctChan <- commitPct

--- a/prevotes/term.go
+++ b/prevotes/term.go
@@ -109,15 +109,24 @@ func DrawScreen(network string, voteChan chan []VoteState, votePctChan, commitPc
 
 func splitVotes(votes []VoteState) ([][]VoteState, int) {
 	split := make([][]VoteState, 0)
+	_, termHeight := ui.TerminalDimensions()
+	validatorRows := termHeight - 10
+
 	var max int
 	switch {
-	case len(votes) < 50:
+	case validatorRows >= len(votes):
 		max = 1
 		split = append(split, votes)
-	case len(votes) < 100:
+	case validatorRows * 2 >= len(votes):
 		max = 2
-		split = append(split, votes[:50])
-		split = append(split, votes[50:])
+		if validatorRows >= 50 {
+			split = append(split, votes[:50])
+			split = append(split, votes[50:])
+		} else {
+			rows := (len(votes) + max - 1)/2
+			split = append(split, votes[:rows])
+			split = append(split, votes[rows:])
+		}
 	default:
 		max = 3
 		rows := (len(votes) + max - 1)/3

--- a/prevotes/term.go
+++ b/prevotes/term.go
@@ -110,29 +110,29 @@ func DrawScreen(network string, voteChan chan []VoteState, votePctChan, commitPc
 func splitVotes(votes []VoteState) ([][]VoteState, int) {
 	split := make([][]VoteState, 0)
 	_, termHeight := ui.TerminalDimensions()
-	validatorRows := termHeight - 10
+	visibleRows := termHeight - 10
 
 	var max int
 	switch {
-	case validatorRows >= len(votes):
+	case visibleRows >= len(votes):
 		max = 1
 		split = append(split, votes)
-	case validatorRows * 2 >= len(votes):
+	case visibleRows * 2 >= len(votes):
 		max = 2
-		if validatorRows >= 50 {
+		if visibleRows >= 50 {
 			split = append(split, votes[:50])
 			split = append(split, votes[50:])
 		} else {
-			rows := (len(votes) + max - 1)/2
-			split = append(split, votes[:rows])
-			split = append(split, votes[rows:])
+			rowsPerColumn := (len(votes) + max - 1)/2
+			split = append(split, votes[:rowsPerColumn])
+			split = append(split, votes[rowsPerColumn:])
 		}
 	default:
 		max = 3
-		rows := (len(votes) + max - 1)/3
-		split = append(split, votes[:rows])
-		split = append(split, votes[rows:rows*2])
-		split = append(split, votes[rows*2:])
+		rowsPerColumn := (len(votes) + max - 1)/3
+		split = append(split, votes[:rowsPerColumn])
+		split = append(split, votes[rowsPerColumn:rowsPerColumn*2])
+		split = append(split, votes[rowsPerColumn*2:])
 	}
 	return split, max
 }


### PR DESCRIPTION
Balanced column fix for:
* Screens for short windows show rank 1..45, then 51+ -- somewhat hiding information

Decimal fraction shown for prevote/commit:
* We always get stuck at 67%, so it's useful to show the decimal digits 67.notenough%